### PR TITLE
新增单曲循环播放模式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .DS_Store
 .idea
 .cursor
+node_modules/
+.runtime/
+music-server/img/
+music-server/song/
+dump.rdb

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
 .DS_Store
 .idea
 .cursor
-node_modules/
-.runtime/
-music-server/img/
-music-server/song/
-dump.rdb

--- a/music-client/src/components/layouts/YinPlayerBar.vue
+++ b/music-client/src/components/layouts/YinPlayerBar.vue
@@ -25,8 +25,10 @@
       </div>
       <div class="playbar__controls">
         <component
-          :is="playStateIndex === 0 ? Repeat : Shuffle"
+          :is="playModeIcon"
           class="playbar__icon-btn hide-mobile"
+          :title="playModeLabel"
+          :aria-label="playModeLabel"
           @click="changePlayState"
         />
         <SkipBack class="playbar__icon-btn" @click="prev" />
@@ -87,6 +89,7 @@ import {
   Pause,
   Play,
   Repeat,
+  Repeat1,
   Shuffle,
   SkipBack,
   SkipForward,
@@ -96,7 +99,12 @@ import {
 import YinAudio from "@/components/player/YinAudio.vue";
 import { useConfigureStore } from "../../store/configure";
 import { useUserStore } from "../../store/user";
-import { useSongStore } from "../../store/song";
+import {
+  PLAY_MODE_LIST_LOOP,
+  PLAY_MODE_SHUFFLE,
+  PLAY_MODE_SINGLE_LOOP,
+  useSongStore,
+} from "../../store/song";
 import {
   fetchCollectionStatus,
   fetchDeleteCollection,
@@ -114,14 +122,20 @@ const { routerManager, playMusic, checkStatus, downloadMusic, attachImageUrl } =
   useAppActions();
 
 const COLLECTION_TYPE_SONG = "0";
-const PLAY_MODE_LOOP = "loop";
-const PLAY_MODE_SHUFFLE = "shuffle";
+const PLAY_MODE_LIST = [
+  PLAY_MODE_LIST_LOOP,
+  PLAY_MODE_SINGLE_LOOP,
+  PLAY_MODE_SHUFFLE,
+];
+const PLAY_MODE_LABEL_MAP = {
+  [PLAY_MODE_LIST_LOOP]: "列表循环",
+  [PLAY_MODE_SINGLE_LOOP]: "单曲循环",
+  [PLAY_MODE_SHUFFLE]: "随机播放",
+};
 
 const nowTime = ref(0);
 const toggle = ref(true);
 const volume = ref(50);
-const playStateList = [PLAY_MODE_LOOP, PLAY_MODE_SHUFFLE];
-const playStateIndex = ref(0);
 
 const isCollection = ref(false);
 const userId = computed(() => userStore.userId);
@@ -139,7 +153,13 @@ const endTime = computed(() => formatSeconds(duration.value));
 const currentPlayList = computed(() => songStore.currentPlayList);
 const currentPlayIndex = computed(() => songStore.currentPlayIndex);
 const autoNext = computed(() => songStore.autoNext);
-const playState = computed(() => playStateList[playStateIndex.value]);
+const playMode = computed(() => songStore.playMode);
+const playModeIcon = computed(() => {
+  if (playMode.value === PLAY_MODE_SINGLE_LOOP) return Repeat1;
+  if (playMode.value === PLAY_MODE_SHUFFLE) return Shuffle;
+  return Repeat;
+});
+const playModeLabel = computed(() => PLAY_MODE_LABEL_MAP[playMode.value]);
 
 watch(songId, initCollection);
 watch(token, (value) => {
@@ -216,10 +236,10 @@ function formatProgressTooltip(value: number) {
 }
 
 function changePlayState() {
-  playStateIndex.value =
-    playStateIndex.value >= playStateList.length - 1
-      ? 0
-      : playStateIndex.value + 1;
+  const currentIndex = PLAY_MODE_LIST.indexOf(playMode.value);
+  const nextIndex =
+    currentIndex >= PLAY_MODE_LIST.length - 1 ? 0 : currentIndex + 1;
+  songStore.setPlayMode(PLAY_MODE_LIST[nextIndex]);
 }
 
 function getRandomPlayIndex(listLength: number) {
@@ -246,7 +266,7 @@ function toPlay(url: string) {
 }
 
 function prev() {
-  if (playState.value === PLAY_MODE_SHUFFLE) {
+  if (playMode.value === PLAY_MODE_SHUFFLE) {
     const playIndex = getRandomPlayIndex(currentPlayList.value.length);
     songStore.setCurrentPlayIndex(playIndex);
     const targetSong = currentPlayList.value[playIndex];
@@ -266,7 +286,7 @@ function prev() {
 }
 
 function next() {
-  if (playState.value === PLAY_MODE_SHUFFLE) {
+  if (playMode.value === PLAY_MODE_SHUFFLE) {
     const playIndex = getRandomPlayIndex(currentPlayList.value.length);
     songStore.setCurrentPlayIndex(playIndex);
     const targetSong = currentPlayList.value[playIndex];

--- a/music-client/src/components/player/YinAudio.vue
+++ b/music-client/src/components/player/YinAudio.vue
@@ -12,12 +12,13 @@
 <script lang="ts" setup>
 import { ref, computed, watch, onMounted } from "vue";
 
-import { useSongStore } from "../../store/song";
+import { PLAY_MODE_SINGLE_LOOP, useSongStore } from "../../store/song";
 import { attachImageUrl } from "../../utils";
 
 const songStore = useSongStore();
 const audioRef = ref<HTMLAudioElement | null>(null);
 const pendingUserGesturePlay = ref(false);
+const playMode = computed(() => songStore.playMode);
 
 const songUrl = computed(() => songStore.songUrl); // 音乐链接
 const isPlay = computed(() => songStore.isPlay); // 播放状态
@@ -36,6 +37,7 @@ watch(volume, (value) => {
     audioRef.value.volume = value;
   }
 });
+watch(playMode, syncAudioLoop, { immediate: true });
 
 async function tryPlay() {
   if (!audioRef.value) return;
@@ -63,6 +65,7 @@ function togglePlay() {
 // 获取歌曲链接后准备播放
 function canplay() {
   if (!audioRef.value) return;
+  syncAudioLoop();
   // 记录音乐时长
   songStore.setDuration(audioRef.value.duration);
   // 开始播放
@@ -77,9 +80,15 @@ function timeupdate() {
 
 // 音乐播放结束时触发
 function ended() {
+  if (playMode.value === PLAY_MODE_SINGLE_LOOP) return;
   songStore.setIsPlay(false);
   songStore.setCurTime(0);
   songStore.setAutoNext(!autoNext.value);
+}
+
+function syncAudioLoop() {
+  if (!audioRef.value) return;
+  audioRef.value.loop = playMode.value === PLAY_MODE_SINGLE_LOOP;
 }
 
 const retryAfterGesture = () => {

--- a/music-client/src/store/song.ts
+++ b/music-client/src/store/song.ts
@@ -1,5 +1,14 @@
 import { defineStore } from "pinia";
 
+export const PLAY_MODE_LIST_LOOP = "listLoop";
+export const PLAY_MODE_SINGLE_LOOP = "singleLoop";
+export const PLAY_MODE_SHUFFLE = "shuffle";
+
+export type PlayMode =
+  | typeof PLAY_MODE_LIST_LOOP
+  | typeof PLAY_MODE_SINGLE_LOOP
+  | typeof PLAY_MODE_SHUFFLE;
+
 export const useSongStore = defineStore("song", {
   state: () => ({
     songId: "" as string | number,
@@ -14,6 +23,7 @@ export const useSongStore = defineStore("song", {
     curTime: 0,
     changeTime: 0,
     autoNext: true,
+    playMode: PLAY_MODE_LIST_LOOP as PlayMode,
     currentPlayList: [] as any[],
     songDetails: null as any,
     currentPlayIndex: -1,
@@ -36,6 +46,9 @@ export const useSongStore = defineStore("song", {
     },
     setAutoNext(autoNext: boolean) {
       this.autoNext = autoNext;
+    },
+    setPlayMode(playMode: PlayMode) {
+      this.playMode = playMode;
     },
     setLyric(lyric: any[]) {
       this.lyric = lyric;


### PR DESCRIPTION
## Summary

新增播放器“单曲循环”模式，播放模式现在支持：

- 列表循环
- 单曲循环
- 随机播放

单曲循环只影响歌曲自然播放结束后的行为；用户手动点击上一首/下一首时，仍然按当前播放队列切换歌曲。

## Changes

- 在 `song` store 中新增播放模式状态 `playMode`
- 新增播放模式常量：`listLoop`、`singleLoop`、`shuffle`
- 底部播放器模式按钮改为三态切换：
  - `Repeat`：列表循环
  - `Repeat1`：单曲循环
  - `Shuffle`：随机播放
- `YinAudio` 在单曲循环模式下启用原生 `audio.loop`
- 单曲循环模式下歌曲自然结束时不再触发自动下一首

## Test

- [x] `npm run lint`
- [x] `npm run build`

## Notes

本 PR 不包含依赖锁定/降级相关改动，不新增后端接口，不新增资源文件。
